### PR TITLE
fix: warn if transparent background is set after opaque init

### DIFF
--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -112,13 +112,15 @@ export class BackgroundSystem implements System<BackgroundSystemOptions>
     set color(value: ColorSource)
     {
         // #if _DEBUG
+        // Warn if transparency is being set after an opaque canvas was initialized.
+        // Canvas alpha settings can't be changed after creation, so this helps developers avoid confusion.
         const incoming = new Color(value);
 
         if (incoming.alpha < 1 && this._backgroundColor.alpha === 1)
         {
             warn(
                 'Cannot set a transparent background on an opaque canvas. '
-            + 'To enable transparency, set backgroundAlpha < 1 when initializing your Application.'
+                + 'To enable transparency, set backgroundAlpha < 1 when initializing your Application.'
             );
         }
         // #endif

--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -111,6 +111,7 @@ export class BackgroundSystem implements System<BackgroundSystemOptions>
 
     set color(value: ColorSource)
     {
+        // #if _DEBUG
         const incoming = new Color(value);
 
         if (incoming.alpha < 1 && this._backgroundColor.alpha === 1)
@@ -120,6 +121,7 @@ export class BackgroundSystem implements System<BackgroundSystemOptions>
             + 'To enable transparency, set backgroundAlpha < 1 when initializing your Application.'
             );
         }
+        // #endif
         this._backgroundColor.setValue(value);
     }
 

--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -1,9 +1,9 @@
 import { Color } from '../../../../color/Color';
 import { ExtensionType } from '../../../../extensions/Extensions';
+import { warn } from '../../../../utils/logging/warn';
 
 import type { ColorSource, RgbaArray } from '../../../../color/Color';
 import type { System } from '../system/System';
-
 /**
  * Options for the background system.
  * @category rendering
@@ -115,12 +115,11 @@ export class BackgroundSystem implements System<BackgroundSystemOptions>
 
         if (incoming.alpha < 1 && this._backgroundColor.alpha === 1)
         {
-            console.warn(
-                '[PixiJS] ✨ Cannot set a transparent background on an opaque canvas. '
+            warn(
+                'Cannot set a transparent background on an opaque canvas. '
             + 'To enable transparency, set backgroundAlpha < 1 when initializing your Application.'
             );
         }
-
         this._backgroundColor.setValue(value);
     }
 

--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -111,6 +111,16 @@ export class BackgroundSystem implements System<BackgroundSystemOptions>
 
     set color(value: ColorSource)
     {
+        const incoming = new Color(value);
+
+        if (incoming.alpha < 1 && this._backgroundColor.alpha === 1)
+        {
+            console.warn(
+                '[PixiJS] ✨ Cannot set a transparent background on an opaque canvas. '
+            + 'To enable transparency, set backgroundAlpha < 1 when initializing your Application.'
+            );
+        }
+
         this._backgroundColor.setValue(value);
     }
 

--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -20,6 +20,9 @@ export interface BackgroundSystemOptions
     background?: ColorSource
     /**
      * Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+     * This value determines whether the canvas is initialized with alpha transparency support.
+     * Note: This cannot be changed after initialization. If set to `1`, the canvas will remain opaque,
+     * even if a transparent background color is set later.
      * @default 1
      */
     backgroundAlpha?: number;
@@ -112,8 +115,7 @@ export class BackgroundSystem implements System<BackgroundSystemOptions>
     set color(value: ColorSource)
     {
         // #if _DEBUG
-        // Warn if transparency is being set after an opaque canvas was initialized.
-        // Canvas alpha settings can't be changed after creation, so this helps developers avoid confusion.
+
         const incoming = new Color(value);
 
         if (incoming.alpha < 1 && this._backgroundColor.alpha === 1)


### PR DESCRIPTION
Fixes #10162

Browsers do not allow changing the canvas alpha setting after initialization. If an Application
is created with `backgroundAlpha: 1`, the canvas becomes opaque and cannot later be made transparent.

This PR adds a helpful developer warning if a transparent background color (e.g., `rgba(...)`) is
set **after** initialization with an opaque background.

This avoids confusion when transparency doesn’t work unexpectedly.

**Console warning example:**




- [x] Lint process passed (`npm run lint`)
- [x] Code builds successfully (`npm run build`)
- [x] Manual test verified (background + warning)
- [ ] No automated tests needed (warning only)